### PR TITLE
Hook analysis command into LLM orchestrator

### DIFF
--- a/scripts/analyze-candidate.ts
+++ b/scripts/analyze-candidate.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { OpeningLabOrchestrator } from '@/features/llm/orchestrator.ts';
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', chunk => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+(async () => {
+  try {
+    const raw = await readStdin();
+    const input = JSON.parse(raw);
+    const orchestrator = new OpeningLabOrchestrator();
+    const result = await orchestrator.analyzeCandidate({
+      candidateId: input.candidateId,
+      manuscriptText: input.manuscriptText,
+      candidateText: input.candidateText,
+    });
+    process.stdout.write(JSON.stringify(result));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(msg);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- pipe analyze_candidate command through Node script invoking OpeningLab orchestrator
- return real confidence, spoiler count, and edit burden to UI

## Testing
- `cargo check` *(fails: gdk-3.0 missing)*
- `npm test` *(fails: performance (~5MB synthesized from fixture) runs scene inventory within threshold)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b48c8ba10083279d7ec3770b77e5e0